### PR TITLE
6 add button to visually expand and popout the embedded lti

### DIFF
--- a/lang/en/filter_lti.php
+++ b/lang/en/filter_lti.php
@@ -31,3 +31,4 @@ $string['filtername'] = 'LTI (External tool) Filter';
 $string['oneormoretagsunmatched'] = '<div><b>Warning: </b>The following name(s) were were not able to be matched: <b>{$a}</b>. Please ensure that the corresponding LTI activity exists in this course.</div><div><small>Students will not see this message.</small></div>';
 $string['pluginname'] = 'LTI (External tool) Filter';
 $string['privacy:metadata'] = 'This plugin does not store any data at all.';
+$string['togglezoom'] = 'Zoom in/out of region';

--- a/lang/en/filter_lti.php
+++ b/lang/en/filter_lti.php
@@ -31,4 +31,4 @@ $string['filtername'] = 'LTI (External tool) Filter';
 $string['oneormoretagsunmatched'] = '<div><b>Warning: </b>The following name(s) were were not able to be matched: <b>{$a}</b>. Please ensure that the corresponding LTI activity exists in this course.</div><div><small>Students will not see this message.</small></div>';
 $string['pluginname'] = 'LTI (External tool) Filter';
 $string['privacy:metadata'] = 'This plugin does not store any data at all.';
-$string['togglezoom'] = 'Zoom in/out of region';
+$string['togglezoom'] = 'Zoom in/out';

--- a/styles.css
+++ b/styles.css
@@ -1,20 +1,27 @@
 div.filter_lti {
     iframe {
-        position: absolute;
-        top: 0;
-        left: 0;
         width: 100%;
         height: 100%;
         border: none;
     }
 
+    .filter_lti_zoom_toggle {
+        opacity: 0;
+        margin: 0;
+        position: absolute;
+        cursor: pointer;
+    }
+
+    label {
+        margin-left: auto;
+        display: block;
+        width: fit-content;
+    }
 
     .filter_lti_inner {
-        position: relative;
         width: 100%;
         height: calc(100vh - 100px - 2em); /* 100px is the size of the Snap header, 2em provides a margin */
         max-height: calc(100vh - 100px - 2em); /* 100px is the size of the Snap header, 2em provides a margin */
-        background-color: #eee;
     }
 
     &.filter_lti_type_mediasite {
@@ -39,6 +46,22 @@ div.filter_lti {
 
         div:has(small) {
             text-align: right;
+        }
+    }
+
+    &:has(.filter_lti_zoom_toggle:checked) {
+        position: fixed;
+        top: 2em;
+        left: 2em;
+        bottom: 2em;
+        right: 2em;
+        background-color: white;
+        box-shadow: 0 8px 16px 0 #0007;
+        padding: 1em;
+        z-index: 1060; /* To go over the Snap header */
+
+        .filter_lti_inner {
+            max-height: calc(100vh - 8em);
         }
     }
 }

--- a/templates/embed-lti.mustache
+++ b/templates/embed-lti.mustache
@@ -40,8 +40,9 @@
     }
 }}
 <div class="filter_lti filter_lti_container filter_lti_type_{{type}}{{#options}} filter_lti_options_{{options}}{{/options}}" data-filter_lti-cmid="{{cmid}}">
+<input type="checkbox" class="filter_lti_zoom_toggle" name="enabled{{cmid}}" id="enabled{{cmid}}"/><label for="enabled{{cmid}}" aria-label="{{#str}}togglezoom, filter_lti{{/str}}" title="{{#str}}togglezoom, filter_lti{{/str}}" class="btn btn-light btn-sm">{{#pix}}e/fullscreen,core{{/pix}}{{#str}}togglezoom, filter_lti{{/str}}</label>
 <div class="filter_lti_inner">
-<iframe class="lti_filter_contentframe" src="{{globals.config.wwwroot}}/mod/lti/launch.php?id={{cmid}}" allowfullscreen="allowfullscreen" style="border: 0;" title="{{title}}">
+<iframe class="lti_filter_contentframe" src="{{globals.config.wwwroot}}/mod/lti/launch.php?id={{cmid}}" allowfullscreen="allowfullscreen" title="{{title}}">
 </iframe>
 </div>
 </div>


### PR DESCRIPTION
This pull request introduces a new "zoom in/out" (fullscreen) feature for embedded LTI (External tool) activities. The main changes include adding a toggle button to expand the LTI iframe, updating styles to support the zoomed state, and adding the relevant language string.

**Feature: LTI Zoom In/Out Functionality**

* Added a checkbox toggle and label button (`filter_lti_zoom_toggle`) to the `embed-lti.mustache` template, allowing users to zoom in/out the LTI iframe. The label uses a fullscreen icon and a new language string for accessibility and clarity.
* Introduced a new language string `togglezoom` in `filter_lti.php` for the zoom button label.

**Styling and Layout Adjustments**

* Updated `styles.css` to style the zoom toggle, position the label, and define the zoomed-in (fullscreen) state using the `:has(.filter_lti_zoom_toggle:checked)` selector. This ensures the LTI iframe expands and overlays the page when zoomed. [[1]](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1L3-L17) [[2]](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1R51-R66)
* Removed unnecessary absolute positioning and background color from the iframe and inner container.